### PR TITLE
depends on geo_types instead of geo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["geo", "polygon", "offset", "margin", "padding"]
 categories = ["algorithms"]
 
 [dependencies]
-geo = "0.25.0"
+geo-types = "0.7"
 itertools = "0.11.0"
 geo-clipper = "0.7.0"
 num-traits = "0.2.8"

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ The following example shows how to compute an inflated line.
 The [`offset`] method is provided by the [`Offset`] trait which is implemented for most [geo-types](https://docs.rs/geo-types/0.4.3/geo_types/).
 
 ```rust
-use geo_types::{Coordinate, Line};
+use geo_types::{Coord, Line};
 use geo_offset::Offset;
 
 let line = Line::new(
-    Coordinate { x: 0.0, y: 0.0 },
-    Coordinate { x: 1.0, y: 8.0 },
+    Coord { x: 0.0, y: 0.0 },
+    Coord { x: 1.0, y: 8.0 },
 );
 
 let line_with_offset = line.offset(2.0)?;

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1,4 +1,4 @@
-type Point = geo::Coordinate<f64>;
+type Point = geo_types::Coord<f64>;
 
 /// This enumeration contains error cases for edges manipulation.
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,12 @@
 //!
 //! ```
 //! # fn main() -> Result<(), geo_offset::OffsetError> {
-//! use geo_types::{Coordinate, Line};
+//! use geo_types::{Coord, Line};
 //! use geo_offset::Offset;
 //!
 //! let line = Line::new(
-//!     Coordinate { x: 0.0, y: 0.0 },
-//!     Coordinate { x: 1.0, y: 8.0 },
+//!     Coord { x: 0.0, y: 0.0 },
+//!     Coord { x: 1.0, y: 8.0 },
 //! );
 //!
 //! let line_with_offset = line.offset(2.0)?;

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -12,7 +12,7 @@ pub enum OffsetError {
 pub const DEFAULT_ARC_SEGMENTS: u32 = 5;
 
 pub trait Offset {
-    fn offset(&self, distance: f64) -> Result<geo::MultiPolygon<f64>, OffsetError> {
+    fn offset(&self, distance: f64) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
         self.offset_with_arc_segments(distance, DEFAULT_ARC_SEGMENTS)
     }
 
@@ -20,16 +20,16 @@ pub trait Offset {
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError>;
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError>;
 }
 
-impl Offset for geo::GeometryCollection<f64> {
+impl Offset for geo_types::GeometryCollection<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
-        let mut geometry_collection_with_offset = geo::MultiPolygon(Vec::new());
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
+        let mut geometry_collection_with_offset = geo_types::MultiPolygon(Vec::new());
         for geometry in self.0.iter() {
             let geometry_with_offset = geometry.offset_with_arc_segments(distance, arc_segments)?;
             geometry_collection_with_offset =
@@ -39,50 +39,54 @@ impl Offset for geo::GeometryCollection<f64> {
     }
 }
 
-impl Offset for geo::Geometry<f64> {
+impl Offset for geo_types::Geometry<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
         match self {
-            geo::Geometry::Point(point) => point.offset_with_arc_segments(distance, arc_segments),
-            geo::Geometry::Line(line) => line.offset_with_arc_segments(distance, arc_segments),
-            geo::Geometry::LineString(line_tring) => {
+            geo_types::Geometry::Point(point) => {
+                point.offset_with_arc_segments(distance, arc_segments)
+            }
+            geo_types::Geometry::Line(line) => {
+                line.offset_with_arc_segments(distance, arc_segments)
+            }
+            geo_types::Geometry::LineString(line_tring) => {
                 line_tring.offset_with_arc_segments(distance, arc_segments)
             }
-            geo::Geometry::Triangle(triangle) => triangle
+            geo_types::Geometry::Triangle(triangle) => triangle
                 .to_polygon()
                 .offset_with_arc_segments(distance, arc_segments),
-            geo::Geometry::Rect(rect) => rect
+            geo_types::Geometry::Rect(rect) => rect
                 .to_polygon()
                 .offset_with_arc_segments(distance, arc_segments),
-            geo::Geometry::Polygon(polygon) => {
+            geo_types::Geometry::Polygon(polygon) => {
                 polygon.offset_with_arc_segments(distance, arc_segments)
             }
-            geo::Geometry::MultiPoint(multi_point) => {
+            geo_types::Geometry::MultiPoint(multi_point) => {
                 multi_point.offset_with_arc_segments(distance, arc_segments)
             }
-            geo::Geometry::MultiLineString(multi_line_string) => {
+            geo_types::Geometry::MultiLineString(multi_line_string) => {
                 multi_line_string.offset_with_arc_segments(distance, arc_segments)
             }
-            geo::Geometry::MultiPolygon(multi_polygon) => {
+            geo_types::Geometry::MultiPolygon(multi_polygon) => {
                 multi_polygon.offset_with_arc_segments(distance, arc_segments)
             }
-            geo::Geometry::GeometryCollection(geometry_collection) => {
+            geo_types::Geometry::GeometryCollection(geometry_collection) => {
                 geometry_collection.offset_with_arc_segments(distance, arc_segments)
             }
         }
     }
 }
 
-impl Offset for geo::MultiPolygon<f64> {
+impl Offset for geo_types::MultiPolygon<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
-        let mut polygons = geo::MultiPolygon(Vec::new());
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
+        let mut polygons = geo_types::MultiPolygon(Vec::new());
         for polygon in self.0.iter() {
             let polygon_with_offset = polygon.offset_with_arc_segments(distance, arc_segments)?;
             polygons = polygons.union(&polygon_with_offset, 1000.0);
@@ -91,16 +95,16 @@ impl Offset for geo::MultiPolygon<f64> {
     }
 }
 
-impl Offset for geo::Polygon<f64> {
+impl Offset for geo_types::Polygon<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
         let exterior_with_offset = self
             .exterior()
             .offset_with_arc_segments(distance.abs(), arc_segments)?;
-        let interiors_with_offset = geo::MultiLineString(self.interiors().to_vec())
+        let interiors_with_offset = geo_types::MultiLineString(self.interiors().to_vec())
             .offset_with_arc_segments(distance.abs(), arc_segments)?;
 
         Ok(if distance.is_sign_positive() {
@@ -113,17 +117,17 @@ impl Offset for geo::Polygon<f64> {
     }
 }
 
-impl Offset for geo::MultiLineString<f64> {
+impl Offset for geo_types::MultiLineString<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
         if distance < 0.0 {
-            return Ok(geo::MultiPolygon(Vec::new()));
+            return Ok(geo_types::MultiPolygon(Vec::new()));
         }
 
-        let mut multi_line_string_with_offset = geo::MultiPolygon(Vec::new());
+        let mut multi_line_string_with_offset = geo_types::MultiPolygon(Vec::new());
         for line_string in self.0.iter() {
             let line_string_with_offset =
                 line_string.offset_with_arc_segments(distance, arc_segments)?;
@@ -134,24 +138,24 @@ impl Offset for geo::MultiLineString<f64> {
     }
 }
 
-impl Offset for geo::LineString<f64> {
+impl Offset for geo_types::LineString<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
         if distance < 0.0 {
-            return Ok(geo::MultiPolygon(Vec::new()));
+            return Ok(geo_types::MultiPolygon(Vec::new()));
         }
 
-        let mut line_string_with_offset = geo::MultiPolygon(Vec::new());
+        let mut line_string_with_offset = geo_types::MultiPolygon(Vec::new());
         for line in self.lines() {
             let line_with_offset = line.offset_with_arc_segments(distance, arc_segments)?;
             line_string_with_offset = line_string_with_offset.union(&line_with_offset, 1000.0);
         }
 
         let line_string_with_offset = line_string_with_offset.0.iter().skip(1).fold(
-            geo::MultiPolygon(
+            geo_types::MultiPolygon(
                 line_string_with_offset
                     .0
                     .get(0)
@@ -165,14 +169,14 @@ impl Offset for geo::LineString<f64> {
     }
 }
 
-impl Offset for geo::Line<f64> {
+impl Offset for geo_types::Line<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
         if distance < 0.0 {
-            return Ok(geo::MultiPolygon(Vec::new()));
+            return Ok(geo_types::MultiPolygon(Vec::new()));
         }
 
         let v1 = &self.start;
@@ -202,27 +206,27 @@ impl Offset for geo::Line<f64> {
                 );
             }
 
-            Ok(geo::MultiPolygon(vec![geo::Polygon::new(
-                geo::LineString(vertices),
+            Ok(geo_types::MultiPolygon(vec![geo_types::Polygon::new(
+                geo_types::LineString(vertices),
                 vec![],
             )]))
         } else {
-            geo::Point::from(self.start).offset_with_arc_segments(distance, arc_segments)
+            geo_types::Point::from(self.start).offset_with_arc_segments(distance, arc_segments)
         }
     }
 }
 
-impl Offset for geo::MultiPoint<f64> {
+impl Offset for geo_types::MultiPoint<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
         if distance < 0.0 {
-            return Ok(geo::MultiPolygon(Vec::new()));
+            return Ok(geo_types::MultiPolygon(Vec::new()));
         }
 
-        let mut multi_point_with_offset = geo::MultiPolygon(Vec::new());
+        let mut multi_point_with_offset = geo_types::MultiPolygon(Vec::new());
         for point in self.0.iter() {
             let point_with_offset = point.offset_with_arc_segments(distance, arc_segments)?;
             multi_point_with_offset = multi_point_with_offset.union(&point_with_offset, 1000.0);
@@ -231,14 +235,14 @@ impl Offset for geo::MultiPoint<f64> {
     }
 }
 
-impl Offset for geo::Point<f64> {
+impl Offset for geo_types::Point<f64> {
     fn offset_with_arc_segments(
         &self,
         distance: f64,
         arc_segments: u32,
-    ) -> Result<geo::MultiPolygon<f64>, OffsetError> {
+    ) -> Result<geo_types::MultiPolygon<f64>, OffsetError> {
         if distance < 0.0 {
-            return Ok(geo::MultiPolygon(Vec::new()));
+            return Ok(geo_types::MultiPolygon(Vec::new()));
         }
 
         let mut angle = 0.0;
@@ -251,14 +255,14 @@ impl Offset for geo::Point<f64> {
         let contour = (0..vertice_count)
             .map(|_| {
                 angle += 2.0 * std::f64::consts::PI / f64::from(vertice_count); // counter-clockwise
-                geo::Coordinate::from((
+                geo_types::Coord::from((
                     self.x() + (distance * angle.cos()),
                     self.y() + (distance * angle.sin()),
                 ))
             })
             .collect();
 
-        Ok(geo::MultiPolygon(vec![geo::Polygon::new(
+        Ok(geo_types::MultiPolygon(vec![geo_types::Polygon::new(
             contour,
             Vec::new(),
         )]))
@@ -266,11 +270,11 @@ impl Offset for geo::Point<f64> {
 }
 
 fn create_arc(
-    vertices: &mut Vec<geo::Coordinate<f64>>,
-    center: &geo::Coordinate<f64>,
+    vertices: &mut Vec<geo_types::Coord<f64>>,
+    center: &geo_types::Coord<f64>,
     radius: f64,
-    start_vertex: &geo::Coordinate<f64>,
-    end_vertex: &geo::Coordinate<f64>,
+    start_vertex: &geo_types::Coord<f64>,
+    end_vertex: &geo_types::Coord<f64>,
     segment_count: u32,
     outwards: bool,
 ) {
@@ -307,7 +311,7 @@ fn create_arc(
     vertices.push(*start_vertex);
     for i in 1..segment_count {
         let angle = start_angle + segment_angle * f64::from(i);
-        vertices.push(geo::Coordinate::from((
+        vertices.push(geo_types::Coord::from((
             center.x + angle.cos() * radius,
             center.y + angle.sin() * radius,
         )));

--- a/src/tests/fixtures.rs
+++ b/src/tests/fixtures.rs
@@ -2,21 +2,21 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 #[allow(dead_code)]
-pub static POLYGONE_POLYLINE: Lazy<geo::GeometryCollection<f64>> = Lazy::new(|| {
+pub static POLYGONE_POLYLINE: Lazy<geo_types::GeometryCollection<f64>> = Lazy::new(|| {
     let data = include_str!("fixtures/polygon_polyline.json");
     let feature_collection: FeatureCollection = serde_json::from_str(&data).unwrap();
     feature_collection.into()
 });
 
 #[allow(dead_code)]
-pub static DEMO: Lazy<geo::GeometryCollection<f64>> = Lazy::new(|| {
+pub static DEMO: Lazy<geo_types::GeometryCollection<f64>> = Lazy::new(|| {
     let data = include_str!("fixtures/demo.json");
     let feature_collection: FeatureCollection = serde_json::from_str(&data).unwrap();
     feature_collection.into()
 });
 
 #[allow(dead_code)]
-pub static DEMO_WITH_OFFSET: Lazy<geo::GeometryCollection<f64>> = Lazy::new(|| {
+pub static DEMO_WITH_OFFSET: Lazy<geo_types::GeometryCollection<f64>> = Lazy::new(|| {
     let data = include_str!("fixtures/demo_with_offset.json");
     let feature_collection: FeatureCollection = serde_json::from_str(&data).unwrap();
     feature_collection.into()
@@ -55,44 +55,44 @@ pub struct Point {
     pub coordinates: (f64, f64),
 }
 
-impl From<FeatureCollection> for geo::GeometryCollection<f64> {
+impl From<FeatureCollection> for geo_types::GeometryCollection<f64> {
     fn from(feature_collection: FeatureCollection) -> Self {
         Self(
             feature_collection
                 .features
                 .iter()
-                .map(|feature| geo::Geometry::from(feature.clone()))
+                .map(|feature| geo_types::Geometry::from(feature.clone()))
                 .collect(),
         )
     }
 }
 
-impl From<Feature> for geo::Geometry<f64> {
+impl From<Feature> for geo_types::Geometry<f64> {
     fn from(feature: Feature) -> Self {
         feature.geometry.into()
     }
 }
 
-impl From<Geometry> for geo::Geometry<f64> {
+impl From<Geometry> for geo_types::Geometry<f64> {
     fn from(geometry: Geometry) -> Self {
         match geometry {
             Geometry::Polygon(polygon) => {
-                let polygon: geo::Polygon<f64> = polygon.into();
+                let polygon: geo_types::Polygon<f64> = polygon.into();
                 polygon.into()
             }
             Geometry::LineString(line_string) => {
-                let line_string: geo::LineString<f64> = line_string.into();
+                let line_string: geo_types::LineString<f64> = line_string.into();
                 line_string.into()
             }
             Geometry::Point(point) => {
-                let point: geo::Point<f64> = point.into();
+                let point: geo_types::Point<f64> = point.into();
                 point.into()
             }
         }
     }
 }
 
-impl From<Polygon> for geo::Polygon<f64> {
+impl From<Polygon> for geo_types::Polygon<f64> {
     fn from(polygon: Polygon) -> Self {
         Self::new(
             polygon
@@ -101,7 +101,7 @@ impl From<Polygon> for geo::Polygon<f64> {
                 .cloned()
                 .unwrap_or_default()
                 .into_iter()
-                .map(geo::Coordinate::from)
+                .map(geo_types::Coord::from)
                 .collect::<Vec<_>>()
                 .into(),
             polygon
@@ -112,7 +112,7 @@ impl From<Polygon> for geo::Polygon<f64> {
                     interior
                         .iter()
                         .cloned()
-                        .map(geo::Coordinate::from)
+                        .map(geo_types::Coord::from)
                         .collect::<Vec<_>>()
                         .into()
                 })
@@ -121,26 +121,26 @@ impl From<Polygon> for geo::Polygon<f64> {
     }
 }
 
-impl From<LineString> for geo::LineString<f64> {
+impl From<LineString> for geo_types::LineString<f64> {
     fn from(line_string: LineString) -> Self {
         Self(
             line_string
                 .coordinates
                 .iter()
-                .map(|coordinate| geo::Coordinate::from(*coordinate))
+                .map(|coordinate| geo_types::Coord::from(*coordinate))
                 .collect(),
         )
     }
 }
 
-impl From<Point> for geo::Point<f64> {
+impl From<Point> for geo_types::Point<f64> {
     fn from(point: Point) -> Self {
         Self::from(point.coordinates)
     }
 }
 
-impl From<geo::GeometryCollection<f64>> for FeatureCollection {
-    fn from(geometry_collection: geo::GeometryCollection<f64>) -> Self {
+impl From<geo_types::GeometryCollection<f64>> for FeatureCollection {
+    fn from(geometry_collection: geo_types::GeometryCollection<f64>) -> Self {
         Self {
             features: geometry_collection
                 .into_iter()
@@ -150,10 +150,10 @@ impl From<geo::GeometryCollection<f64>> for FeatureCollection {
     }
 }
 
-impl From<geo::Geometry<f64>> for FeatureCollection {
-    fn from(geometry: geo::Geometry<f64>) -> Self {
+impl From<geo_types::Geometry<f64>> for FeatureCollection {
+    fn from(geometry: geo_types::Geometry<f64>) -> Self {
         match geometry {
-            geo::Geometry::Polygon(polygon) => {
+            geo_types::Geometry::Polygon(polygon) => {
                 let polygon: Polygon = polygon.into();
                 Self {
                     features: vec![Feature {
@@ -161,7 +161,7 @@ impl From<geo::Geometry<f64>> for FeatureCollection {
                     }],
                 }
             }
-            geo::Geometry::LineString(line_string) => {
+            geo_types::Geometry::LineString(line_string) => {
                 let line_string: LineString = line_string.into();
                 Self {
                     features: vec![Feature {
@@ -169,7 +169,7 @@ impl From<geo::Geometry<f64>> for FeatureCollection {
                     }],
                 }
             }
-            geo::Geometry::Point(point) => {
+            geo_types::Geometry::Point(point) => {
                 let point: Point = point.into();
                 Self {
                     features: vec![Feature {
@@ -177,14 +177,14 @@ impl From<geo::Geometry<f64>> for FeatureCollection {
                     }],
                 }
             }
-            geo::Geometry::MultiPolygon(multi_polygon) => multi_polygon.into(),
+            geo_types::Geometry::MultiPolygon(multi_polygon) => multi_polygon.into(),
             _ => unimplemented!(),
         }
     }
 }
 
-impl From<geo::MultiPolygon<f64>> for FeatureCollection {
-    fn from(multi_polygon: geo::MultiPolygon<f64>) -> Self {
+impl From<geo_types::MultiPolygon<f64>> for FeatureCollection {
+    fn from(multi_polygon: geo_types::MultiPolygon<f64>) -> Self {
         Self {
             features: multi_polygon
                 .into_iter()
@@ -196,8 +196,8 @@ impl From<geo::MultiPolygon<f64>> for FeatureCollection {
     }
 }
 
-impl From<geo::Polygon<f64>> for Polygon {
-    fn from(polygon: geo::Polygon<f64>) -> Self {
+impl From<geo_types::Polygon<f64>> for Polygon {
+    fn from(polygon: geo_types::Polygon<f64>) -> Self {
         Self {
             coordinates: vec![polygon
                 .exterior()
@@ -209,19 +209,19 @@ impl From<geo::Polygon<f64>> for Polygon {
     }
 }
 
-impl From<geo::LineString<f64>> for LineString {
-    fn from(line_string: geo::LineString<f64>) -> Self {
+impl From<geo_types::LineString<f64>> for LineString {
+    fn from(line_string: geo_types::LineString<f64>) -> Self {
         Self {
             coordinates: line_string
-                .points_iter()
+                .points()
                 .map(|coords| (coords.x(), coords.y()))
                 .collect(),
         }
     }
 }
 
-impl From<geo::Point<f64>> for Point {
-    fn from(point: geo::Point<f64>) -> Self {
+impl From<geo_types::Point<f64>> for Point {
+    fn from(point: geo_types::Point<f64>) -> Self {
         Self {
             coordinates: (point.x(), point.y()),
         }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,75 +1,75 @@
 use super::*;
-use geo::{Coordinate, LineString, Polygon};
 use geo_svg::*;
+use geo_types::{Coord, LineString, Polygon};
 
 mod fixtures;
 
 #[test]
 fn test_edge() {
     let edge = Edge::new(&(0.0, 0.0).into(), &(0.0, 5.0).into());
-    assert_eq!(geo::Coordinate::from((0.0, 0.0)), edge.current);
-    assert_eq!(geo::Coordinate::from((0.0, 5.0)), edge.next);
+    assert_eq!(geo_types::Coord::from((0.0, 0.0)), edge.current);
+    assert_eq!(geo_types::Coord::from((0.0, 5.0)), edge.next);
     assert_eq!(
-        geo::Coordinate::from((-1.0, 0.0)),
+        geo_types::Coord::from((-1.0, 0.0)),
         edge.inwards_normal().unwrap()
     );
     assert_eq!(
-        geo::Coordinate::from((1.0, 0.0)),
+        geo_types::Coord::from((1.0, 0.0)),
         edge.outwards_normal().unwrap()
     );
 }
 
 #[test]
 fn test_point_offset() {
-    let point = geo::Point::new(0.0, 0.0);
+    let point = geo_types::Point::new(0.0, 0.0);
     let result = point.offset_with_arc_segments(1.0, 5).unwrap();
-    let expected = geo::MultiPolygon(vec![Polygon::new(
+    let expected = geo_types::MultiPolygon(vec![Polygon::new(
         LineString(vec![
-            Coordinate {
+            Coord {
                 x: 0.841_253_532_831_181_2,
                 y: 0.540_640_817_455_597_6,
             },
-            Coordinate {
+            Coord {
                 x: 0.415_415_013_001_886_44,
                 y: 0.909_631_995_354_518_3,
             },
-            Coordinate {
+            Coord {
                 x: -0.142_314_838_273_285,
                 y: 0.989_821_441_880_932_8,
             },
-            Coordinate {
+            Coord {
                 x: -0.654_860_733_945_285,
                 y: 0.755_749_574_354_258_3,
             },
-            Coordinate {
+            Coord {
                 x: -0.959_492_973_614_497_4,
                 y: 0.281_732_556_841_429_67,
             },
-            Coordinate {
+            Coord {
                 x: -0.959_492_973_614_497_4,
                 y: -0.281_732_556_841_429_84,
             },
-            Coordinate {
+            Coord {
                 x: -0.654_860_733_945_284_9,
                 y: -0.755_749_574_354_258_5,
             },
-            Coordinate {
+            Coord {
                 x: -0.142_314_838_273_285_23,
                 y: -0.989_821_441_880_932_7,
             },
-            Coordinate {
+            Coord {
                 x: 0.415_415_013_001_886_05,
                 y: -0.909_631_995_354_518_6,
             },
-            Coordinate {
+            Coord {
                 x: 0.841_253_532_831_180_8,
                 y: -0.540_640_817_455_598_2,
             },
-            Coordinate {
+            Coord {
                 x: 1.0,
                 y: -0.000_000_000_000_001_133_107_779_529_596,
             },
-            Coordinate {
+            Coord {
                 x: 0.841_253_532_831_181_2,
                 y: 0.540_640_817_455_597_6,
             },
@@ -83,9 +83,9 @@ fn test_point_offset() {
 
 #[test]
 fn test_segment_offset() {
-    let p1 = geo::Coordinate::from((0.0, 0.0));
-    let p2 = geo::Coordinate::from((0.0, 8.0));
-    let segment = geo::Line::new(p1, p2);
+    let p1 = geo_types::Coord::from((0.0, 0.0));
+    let p2 = geo_types::Coord::from((0.0, 8.0));
+    let segment = geo_types::Line::new(p1, p2);
     let result = segment.offset(5.0).unwrap();
 
     println!(
@@ -96,7 +96,7 @@ fn test_segment_offset() {
 
 #[test]
 fn test_polygon_offset() {
-    use geo::polygon;
+    use geo_types::polygon;
     let polygon = polygon![
         (x: -10., y: 10.),
         (x: 10., y: 10.),
@@ -113,7 +113,7 @@ fn test_polygon_offset() {
 
 #[test]
 fn test_polygon_with_hole_offset() {
-    use geo::polygon;
+    use geo_types::polygon;
     let polygon = polygon![
         exterior: [
         (x: -15., y: 15.),
@@ -145,5 +145,5 @@ fn test_demo_offset() {
             .with_margin(0.001)
     );
 
-    // assert_eq!(*fixtures::DEMO_WITH_OFFSET, geo::GeometryCollection::from(fixtures::FeatureCollection::from(result)));
+    // assert_eq!(*fixtures::DEMO_WITH_OFFSET, geo_types::GeometryCollection::from(fixtures::FeatureCollection::from(result)));
 }


### PR DESCRIPTION
improve compatibility by depending on `geo_types` instead of `geo`.

Also fixes a few deprecation warnings