### PR TITLE
add support for f32 variant of geo types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,4 @@ serde_json = "1.0.40"
 once_cell = "1.4.0"
 data-uri-utils = "0.2.0"
 geo-svg = "0.5.0"
-geo-types = "0.7.1"
-
-[patch.crates-io]
-geo-clipper = { git = "https://github.com/lelongg/geo-clipper" }
+geo-types = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ once_cell = "1.4.0"
 data-uri-utils = "0.2.0"
 geo-svg = "0.5.0"
 geo-types = "0.7.1"
+
+[patch.crates-io]
+geo-clipper = { git = "https://github.com/lelongg/geo-clipper" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["algorithms"]
 [dependencies]
 geo-types = "0.7"
 itertools = "0.11.0"
-geo-clipper = "0.7.0"
+geo-clipper = "0.8.0"
 num-traits = "0.2.8"
 
 [dev-dependencies]
@@ -23,4 +23,4 @@ serde_json = "1.0.40"
 once_cell = "1.4.0"
 data-uri-utils = "0.2.0"
 geo-svg = "0.5.0"
-geo-types = "0.8.0"
+geo-types = "0.7.1"

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1,4 +1,6 @@
-type Point = geo_types::Coord<f64>;
+use geo_types::CoordFloat;
+
+type Point<F> = geo_types::Coord<F>;
 
 /// This enumeration contains error cases for edges manipulation.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -8,27 +10,27 @@ pub enum EdgeError {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Edge {
-    pub current: Point,
-    pub next: Point,
+pub struct Edge<F: CoordFloat> {
+    pub current: Point<F>,
+    pub next: Point<F>,
 }
 
-impl Edge {
-    pub fn new(current: &Point, next: &Point) -> Self {
+impl<F: CoordFloat> Edge<F> {
+    pub fn new(current: &Point<F>, next: &Point<F>) -> Self {
         Self {
             current: *current,
             next: *next,
         }
     }
 
-    pub fn new_with_offset(current: &Point, next: &Point, dx: f64, dy: f64) -> Self {
+    pub fn new_with_offset(current: &Point<F>, next: &Point<F>, dx: F, dy: F) -> Self {
         Self {
             current: (current.x + dx, current.y + dy).into(),
             next: (next.x + dx, next.y + dy).into(),
         }
     }
 
-    pub fn inwards_normal(&self) -> Result<Point, EdgeError> {
+    pub fn inwards_normal(&self) -> Result<Point<F>, EdgeError> {
         let dx = self.next.x - self.current.x;
         let dy = self.next.y - self.current.y;
         let edge_length = (dx * dx + dy * dy).sqrt();
@@ -42,16 +44,16 @@ impl Edge {
         }
     }
 
-    pub fn outwards_normal(&self) -> Result<Point, EdgeError> {
+    pub fn outwards_normal(&self) -> Result<Point<F>, EdgeError> {
         let inwards = self.inwards_normal()?;
         Ok((-inwards.x, -inwards.y).into())
     }
 
-    pub fn with_offset(&self, dx: f64, dy: f64) -> Self {
+    pub fn with_offset(&self, dx: F, dy: F) -> Self {
         Self::new_with_offset(&self.current, &self.next, dx, dy)
     }
 
-    pub fn inverse_with_offset(&self, dx: f64, dy: f64) -> Self {
+    pub fn inverse_with_offset(&self, dx: F, dy: F) -> Self {
         Self::new_with_offset(&self.next, &self.current, dx, dy)
     }
 


### PR DESCRIPTION
accept `CordFloat` instead of `f64`, so that `f32` variants are accepted

depends on https://github.com/lelongg/geo-clipper/pull/23 being released 🙂 