### PR TITLE
Make it possible to target arc segment length

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,61 +19,83 @@ fn test_edge() {
     );
 }
 
+const POINT_OFFSET_COORDS: [Coord; 12] = [
+    Coord {
+        x: 0.841_253_532_831_181_2,
+        y: 0.540_640_817_455_597_6,
+    },
+    Coord {
+        x: 0.415_415_013_001_886_44,
+        y: 0.909_631_995_354_518_3,
+    },
+    Coord {
+        x: -0.142_314_838_273_285,
+        y: 0.989_821_441_880_932_8,
+    },
+    Coord {
+        x: -0.654_860_733_945_285,
+        y: 0.755_749_574_354_258_3,
+    },
+    Coord {
+        x: -0.959_492_973_614_497_4,
+        y: 0.281_732_556_841_429_67,
+    },
+    Coord {
+        x: -0.959_492_973_614_497_4,
+        y: -0.281_732_556_841_429_84,
+    },
+    Coord {
+        x: -0.654_860_733_945_284_9,
+        y: -0.755_749_574_354_258_5,
+    },
+    Coord {
+        x: -0.142_314_838_273_285_23,
+        y: -0.989_821_441_880_932_7,
+    },
+    Coord {
+        x: 0.415_415_013_001_886_05,
+        y: -0.909_631_995_354_518_6,
+    },
+    Coord {
+        x: 0.841_253_532_831_180_8,
+        y: -0.540_640_817_455_598_2,
+    },
+    Coord {
+        x: 1.0,
+        y: -0.000_000_000_000_001_133_107_779_529_596,
+    },
+    Coord {
+        x: 0.841_253_532_831_181_2,
+        y: 0.540_640_817_455_597_6,
+    },
+];
+
 #[test]
 fn test_point_offset() {
     let point = geo_types::Point::new(0.0, 0.0);
-    let result = point.offset_with_arc_resolution(1.0, ArcResolution::SegmentCount(11)).unwrap();
+    let resolution = ArcResolution::SegmentCount(POINT_OFFSET_COORDS.len() - 1); // -1 because the test LineString is closed
+    let result = point.offset_with_arc_resolution(1.0, resolution).unwrap();
     let expected = geo_types::MultiPolygon(vec![Polygon::new(
-        LineString(vec![
-            Coord {
-                x: 0.841_253_532_831_181_2,
-                y: 0.540_640_817_455_597_6,
-            },
-            Coord {
-                x: 0.415_415_013_001_886_44,
-                y: 0.909_631_995_354_518_3,
-            },
-            Coord {
-                x: -0.142_314_838_273_285,
-                y: 0.989_821_441_880_932_8,
-            },
-            Coord {
-                x: -0.654_860_733_945_285,
-                y: 0.755_749_574_354_258_3,
-            },
-            Coord {
-                x: -0.959_492_973_614_497_4,
-                y: 0.281_732_556_841_429_67,
-            },
-            Coord {
-                x: -0.959_492_973_614_497_4,
-                y: -0.281_732_556_841_429_84,
-            },
-            Coord {
-                x: -0.654_860_733_945_284_9,
-                y: -0.755_749_574_354_258_5,
-            },
-            Coord {
-                x: -0.142_314_838_273_285_23,
-                y: -0.989_821_441_880_932_7,
-            },
-            Coord {
-                x: 0.415_415_013_001_886_05,
-                y: -0.909_631_995_354_518_6,
-            },
-            Coord {
-                x: 0.841_253_532_831_180_8,
-                y: -0.540_640_817_455_598_2,
-            },
-            Coord {
-                x: 1.0,
-                y: -0.000_000_000_000_001_133_107_779_529_596,
-            },
-            Coord {
-                x: 0.841_253_532_831_181_2,
-                y: 0.540_640_817_455_597_6,
-            },
-        ]),
+        LineString(Vec::from(POINT_OFFSET_COORDS)),
+        Vec::new(),
+    )]);
+
+    println!("{}", result.to_svg().and(point.to_svg()).with_margin(10.0));
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn test_point_offset_targeting_segment_length() {
+    let point = geo_types::Point::new(0.0, 0.0);
+
+    let radius = 1.0;
+    let segments_expected = POINT_OFFSET_COORDS.len() - 1; // -1 because the test LineString is closed
+    let segment_length = radius * std::f64::consts::TAU / segments_expected as f64;
+    let resolution = ArcResolution::SegmentLength(segment_length);
+
+    let result = point.offset_with_arc_resolution(radius, resolution).unwrap();
+    let expected = geo_types::MultiPolygon(vec![Polygon::new(
+        LineString(Vec::from(POINT_OFFSET_COORDS)),
         Vec::new(),
     )]);
 
@@ -128,6 +150,28 @@ fn test_polygon_with_hole_offset() {
     ]]];
 
     let result = polygon.offset(1.0).unwrap();
+
+    println!("{}", result.to_svg().and(polygon.to_svg()).with_margin(5.0));
+}
+
+#[test]
+fn test_polygon_with_hole_offset_high_resolution() {
+    use geo_types::polygon;
+    let polygon = polygon![
+        exterior: [
+        (x: -15., y: 15.),
+        (x: 15., y: 15.),
+        (x: 15., y: -15.),
+        (x: -15., y: -15.),],
+        interiors: [[
+            (x: -10., y: 10.),
+            (x: 10., y: 10.),
+            (x: 10., y: -10.),
+            (x: -10., y: -10.),
+    ]]];
+
+    let resolution = ArcResolution::SegmentLength(0.1);
+    let result = polygon.offset_with_arc_resolution(1.0, resolution).unwrap();
 
     println!("{}", result.to_svg().and(polygon.to_svg()).with_margin(5.0));
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -22,7 +22,7 @@ fn test_edge() {
 #[test]
 fn test_point_offset() {
     let point = geo_types::Point::new(0.0, 0.0);
-    let result = point.offset_with_arc_segments(1.0, 5).unwrap();
+    let result = point.offset_with_arc_resolution(1.0, ArcResolution::SegmentCount(11)).unwrap();
     let expected = geo_types::MultiPolygon(vec![Polygon::new(
         LineString(vec![
             Coord {
@@ -134,7 +134,7 @@ fn test_polygon_with_hole_offset() {
 
 #[test]
 fn test_demo_offset() {
-    let result = fixtures::DEMO.offset_with_arc_segments(0.0001, 5).unwrap();
+    let result = fixtures::DEMO.offset_with_arc_resolution(0.0001, ArcResolution::SegmentCount(5)).unwrap();
 
     println!(
         "{}",


### PR DESCRIPTION
This adds an `enum ArcResolution` that allows selecting whether the arc should have a fixed number of segments, or if the number of segments should depend on the arc length.

Note: there was some interesting `vertice_count` calculation that I removed:
```
        let vertice_count = match arc_segments * 2 {
            count if count % 2 == 0 => count + 1,
            count => count,
        };
```
That code was equivalent to `let vertice_count = arc_segments * 2 + 1`.

Note: there was also a calculation making `segment_count` an odd number that I removed too:
```
    let segment_count = if segment_count % 2 == 0 {
        segment_count - 1
    } else {
        segment_count
    };
```
What was the intention there?

By the way, setting resolution to be based on segment length helps with artifacts from #27 